### PR TITLE
feat: Highlight hover and active header cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@superset-ui/react-pivottable",
-  "version": "0.12.5",
-  "description": "A React-based pivot table (based on https://github.com/plotly/react-pivottable)",
+  "version": "0.12.6",
+  "description": "A React-based pivot table (based on https://github.com/apache-superset/react-pivottable)",
   "main": "PivotTableUI.js",
   "files": [
     "PivotTable.js",
@@ -28,7 +28,6 @@
     "build": "npm run clean && cp src/pivottable.css . && babel src --out-dir=. --source-maps --presets=env,react --plugins babel-plugin-add-module-exports",
     "doPublish": "npm run build && npm publish",
     "postpublish": "npm run clean",
-    "deploy": "webpack -p && mv bundle.js examples && cd examples && git init && git add . && git commit -m build && git push --force git@github.com:plotly/react-pivottable.git master:gh-pages && rm -rf .git bundle.js"
   },
   "repository": {
     "type": "git",

--- a/src/TableRenderers.jsx
+++ b/src/TableRenderers.jsx
@@ -510,6 +510,11 @@ function makeRenderer(opts = {}) {
         maxColVisible,
         pivotData,
       } = pivotSettings;
+      const {
+        highlightHeaderCellsOnHover,
+        omittedHighlightHeaderGroups = [],
+        highlightedHeaderCells,
+      } = this.props.tableOptions;
 
       const spaceCell =
         attrIdx === 0 && rowAttrs.length !== 0 ? (
@@ -535,17 +540,7 @@ function makeRenderer(opts = {}) {
           (attrIdx + 1 < maxColVisible ? arrowExpanded : arrowCollapsed) + ' ';
       }
       const attrNameCell = (
-        <th
-          key="label"
-          className="pvtAxisLabel"
-          onClick={this.clickHeaderHandler(
-            pivotData,
-            colAttrs,
-            this.props.cols,
-            attrIdx,
-            this.props.tableOptions.clickColumnHeaderCallback
-          )}
-        >
+        <th key="label" className="pvtAxisLabel">
           {displayHeaderCell(needToggle, subArrow, arrowClickHandle, attrName)}
         </th>
       );
@@ -557,9 +552,25 @@ function makeRenderer(opts = {}) {
       while (i < visibleColKeys.length) {
         const colKey = visibleColKeys[i];
         const colSpan = attrIdx < colKey.length ? colAttrSpans[i][attrIdx] : 1;
-        const colLabelClass =
-          colSpan > 1 ? 'pvtColLabel' : 'pvtColLabel label-centered';
+        let colLabelClass = 'pvtColLabel';
+        if (colSpan > 1) {
+          colLabelClass += ' label-centered';
+        }
         if (attrIdx < colKey.length) {
+          if (
+            highlightHeaderCellsOnHover &&
+            !omittedHighlightHeaderGroups.includes(colAttrs[attrIdx])
+          ) {
+            colLabelClass += ' hoverable';
+          }
+          if (
+            highlightedHeaderCells &&
+            Array.isArray(highlightedHeaderCells[colAttrs[attrIdx]]) &&
+            highlightedHeaderCells[colAttrs[attrIdx]].includes(colKey[attrIdx])
+          ) {
+            colLabelClass += ' active';
+          }
+
           const rowSpan =
             1 + (attrIdx === colAttrs.length - 1 ? rowIncrSpan : 0);
           const flatColKey = flatKey(colKey.slice(0, attrIdx + 1));
@@ -671,17 +682,7 @@ function makeRenderer(opts = {}) {
                 (i + 1 < maxRowVisible ? arrowExpanded : arrowCollapsed) + ' ';
             }
             return (
-              <th
-                className="pvtAxisLabel"
-                key={`rowAttr-${i}`}
-                onClick={this.clickHeaderHandler(
-                  pivotData,
-                  rowAttrs,
-                  this.props.rows,
-                  i,
-                  this.props.tableOptions.clickRowHeaderCallback
-                )}
-              >
+              <th className="pvtAxisLabel" key={`rowAttr-${i}`}>
                 {displayHeaderCell(
                   needLabelToggle,
                   subArrow,
@@ -730,10 +731,29 @@ function makeRenderer(opts = {}) {
         rowTotalCallbacks,
       } = pivotSettings;
 
+      const {
+        highlightHeaderCellsOnHover,
+        omittedHighlightHeaderGroups = [],
+        highlightedHeaderCells,
+      } = this.props.tableOptions;
       const flatRowKey = flatKey(rowKey);
 
       const colIncrSpan = colAttrs.length !== 0 ? 1 : 0;
       const attrValueCells = rowKey.map((r, i) => {
+        let valueCellClassName = 'pvtRowLabel';
+        if (
+          highlightHeaderCellsOnHover &&
+          !omittedHighlightHeaderGroups.includes(rowAttrs[i])
+        ) {
+          valueCellClassName += ' hoverable';
+        }
+        if (
+          highlightedHeaderCells &&
+          Array.isArray(highlightedHeaderCells[rowAttrs[i]]) &&
+          highlightedHeaderCells[rowAttrs[i]].includes(r)
+        ) {
+          valueCellClassName += ' active';
+        }
         const rowSpan = rowAttrSpans[rowIdx][i];
         if (rowSpan > 0) {
           const flatRowKey = flatKey(rowKey.slice(0, i + 1));
@@ -748,7 +768,7 @@ function makeRenderer(opts = {}) {
           return (
             <th
               key={`rowKeyLabel-${i}`}
-              className="pvtRowLabel"
+              className={valueCellClassName}
               rowSpan={rowSpan}
               colSpan={colSpan}
               onClick={this.clickHeaderHandler(

--- a/src/pivottable.css
+++ b/src/pivottable.css
@@ -32,6 +32,10 @@ table.pvtTable tbody tr th {
     font-weight: normal;
 }
 
+table.pvtTable tr th.active {
+    background-color: #D9DBE4;
+}
+
 table.pvtTable .pvtTotalLabel {
     text-align: right;
     font-weight: bold;
@@ -346,5 +350,10 @@ table.pvtTable tbody tr td.pvtRowTotal {
 }
 
 .toggle {
+    cursor: pointer;
+}
+
+.hoverable:hover {
+    background-color: #ECEEF2;
     cursor: pointer;
 }


### PR DESCRIPTION
Highlights header cells on hover when prop `tableOptions.highlightHeaderCellsOnHover` is enabled.
Highlights selected header cells based on prop `tableOptions.highlightedHeaderCells`.
Disables groups of header cells from highlighting on hover based on prop `tableOptions.omittedHighlightHeaderGroups`.

![image](https://user-images.githubusercontent.com/15073128/116717566-4ecd3200-a9d9-11eb-881b-f91204022c63.png)
